### PR TITLE
Error handle large images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ notebooks/handler.ipynb
 grafana-enterprise_9.4.7_amd64.deb
 .devcontainer/
 .vscode/
+logs/
+model-store/

--- a/Dockerfile-cpu
+++ b/Dockerfile-cpu
@@ -14,8 +14,6 @@ COPY ./deployment/append_memory_setting.sh /home/model-server/append_memory_sett
 RUN chmod +x /home/model-server/append_memory_setting.sh \
     && /home/model-server/append_memory_setting.sh
 
-COPY handler*.py ./
-
 COPY start ./
 
 WORKDIR /home/model-server

--- a/Dockerfile-gpu
+++ b/Dockerfile-gpu
@@ -14,8 +14,6 @@ COPY ./deployment/append_memory_setting.sh /home/model-server/append_memory_sett
 RUN chmod +x /home/model-server/append_memory_setting.sh \
     && /home/model-server/append_memory_setting.sh
 
-COPY handler*.py ./
-
 COPY start ./
 
 WORKDIR /home/model-server

--- a/README.md
+++ b/README.md
@@ -2,26 +2,44 @@
 
 ## Quickstart
 
+### Building the container for creating the .mar archives
+
+Both models will be downloaded using the vit_h weights.
+
+```
+docker build -t sam-builder -f Dockerfile-build . 
+```
+
+### Copying the .mar archives to host for local testing
+
+```
+docker cp sam_builder_1:/home/model-store ./
+```
+
+We copy these to model-store and use this locally by both the GPU and the CPU Torchserve containers.
+
+you can delete the container once models are copied
+
+```
+docker rm -f sam_builder_1
+```
+
 ### Building the gpu torchserve container for image encoding
 With the GPU, inference time should be about 1.8 seconds or less depending on the GPU. On an older 1080 Ti Pascal GPU, inference time is 1.67 seconds without compilation.
 
 ```
-docker build -t torchserve-sam-gpu -f Dockerfile-gpu .
+docker build -t sam-gpu -f Dockerfile-gpu .
 bash start_serve_encode_gpu.sh
 ```
 
 ### Building the cpu torchserve container for image decoding
 
 ```
-docker build -t torchserve-sam-cpu -f Dockerfile-cpu .
+docker build -t sam-cpu -f Dockerfile-cpu .
 bash start_serve_decode_cpu.sh
 ```
 
-For both containers, both models will be downloaded using the vit_h weights and available as endpoints, but it is recommended to use the GPU for encoding and CPU for decoding.
-
-## Local Setup
-
-This project contains two seperate Torchserve services, one for the encoder (best run on a GPU) and the decoder (CPU). Check out the [original repo](https://github.com/facebookresearch/segment-anything) for more info.
+## Local Setup without Docker
 
 ### 1. Downloading model weights
 

--- a/deployment/config_encode.properties
+++ b/deployment/config_encode.properties
@@ -1,8 +1,10 @@
 inference_address=http://0.0.0.0:8080
 management_address=http://0.0.0.0:8081
-number_of_netty_threads=4
+number_of_netty_threads=1
 default_workers_per_model=1
 job_queue_size=1000
 model_store=/home/model-server/volume/model-store
 load_models=all
 vmargs=-Xmx8g
+max_request_size=17797905
+max_response_size=17797905

--- a/handler_encode.py
+++ b/handler_encode.py
@@ -12,6 +12,7 @@ from io import BytesIO
 from typing import Union
 import os
 from time import time
+import json
 from segment_anything import sam_model_registry, SamPredictor
 # import ptvsd
 
@@ -148,7 +149,6 @@ def open_image(input_file: Union[str, BytesIO]) -> Image:
         except Exception as e:
             print(f'Error opening image {input_file}: {e}')
             raise
-
     else:
         print("trying to open image")
         image = Image.open(input_file)
@@ -172,7 +172,8 @@ def open_image(input_file: Union[str, BytesIO]) -> Image:
             image = image.rotate(IMAGE_ROTATIONS[orientation], expand=True)  # returns a rotated copy
     except Exception:
         pass
-
+    if image.size[0] * img.size[1] > 2048*2048:
+        raise ValueError(f"Image size {image.size} exceeded the 2048x2048 input size limit. Tile your image and submit tiles individually or resize the image to a smaller size.")
     return image
 
 

--- a/notebooks/test_endpoint.ipynb
+++ b/notebooks/test_endpoint.ipynb
@@ -22,8 +22,9 @@
     "from io import BytesIO\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
+    "import json\n",
     "encode_url=\"http://127.0.0.1:8080/predictions/sam_vit_h_encode\" # make sure to select correct port. 70* for cpu, 80* for gpu\n",
-    "#encode_url = \"https://sas.ds.io/predictions/sam_vit_h_encode\"\n",
+    "#encode_url = \"https://segme-gpuel-ekfao79wi98g-617785108.us-east-1.elb.amazonaws.com/predictions/sam_vit_h_encode\"\n",
     "pth_fox = \"../data/sample-img-fox.jpg\"\n",
     "input_point_fox = (150, 75)\n",
     "\n",
@@ -53,8 +54,81 @@
    },
    "outputs": [],
    "source": [
+    "Image.open(\"../data/wuPwKFUZ.jpeg\").size"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
     "img_slick = Image.open(pth_slick)\n",
     "autocontrast(img_slick, cutoff=0, ignore=None, mask=None, preserve_tone=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import io\n",
+    "def generate_dummy_array_and_encode(shape):\n",
+    "    # Create a dummy 3-channel numpy array with the given shape\n",
+    "    dummy_array = np.random.randint(0, 256, size=(shape[0], shape[1], 3), dtype=np.uint8)\n",
+    "\n",
+    "    # Convert the numpy array to an image\n",
+    "    img = Image.fromarray(dummy_array)\n",
+    "\n",
+    "    # Save the image to a buffer in PNG format\n",
+    "    buffer = io.BytesIO()\n",
+    "    img.save(buffer, format='PNG')\n",
+    "    buffer.seek(0)\n",
+    "\n",
+    "    # Encode the buffer content as base64\n",
+    "    encoded_image = base64.b64encode(buffer.getvalue()).decode('utf-8')\n",
+    "\n",
+    "    # Store the encoded image in a dictionary\n",
+    "    result = {'encoded_image': encoded_image}\n",
+    "\n",
+    "    return result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Testing arbitrarily sized images, 2049 or greater should error 500 with detailed message."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "shape = (2049, 2049)\n",
+    "payload = generate_dummy_array_and_encode(shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "try:\n",
+    "    response = httpx.post(encode_url, json=payload, timeout=None)\n",
+    "except (BrokenPipeError, httpx.RemoteProtocolError) as e:\n",
+    "    print(\"wait and try again\")"
    ]
   },
   {
@@ -75,7 +149,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Time to encode image on 1080 Ti GPU"
    ]
@@ -91,8 +167,30 @@
     "%%time\n",
     "try:\n",
     "    response = httpx.post(encode_url, json=payload, timeout=None)\n",
-    "except BrokenPipeError:\n",
+    "except (BrokenPipeError, httpx.RemoteProtocolError) as e:\n",
     "    print(\"wait and try again\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response.content"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response"
    ]
   },
   {
@@ -152,6 +250,17 @@
     "decode_url=\"http://127.0.0.1:8080/predictions/sam_vit_h_decode\" # make sure to select correct port. 70* for cpu, 80* for gpu\n",
     "#decode_url=\"https://sas.ds.io/predictions/sam_vit_h_decode\"\n",
     "response = httpx.post(decode_url, json=decode_payload, timeout=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response"
    ]
   },
   {
@@ -242,9 +351,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:segment-geo]",
+   "display_name": "Python [conda env:root] *",
    "language": "python",
-   "name": "conda-env-segment-geo-py"
+   "name": "conda-root-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -256,7 +365,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.10.9"
   },
   "vscode": {
    "interpreter": {

--- a/start_serve_decode_cpu.sh
+++ b/start_serve_decode_cpu.sh
@@ -1,1 +1,1 @@
-docker run -it -p 7080:7080 -p 7081:7081 -p 7082:7082 torchserve-sam-cpu:latest serve
+docker run -it --rm -p 8080:8080 -p 8081:8081 -p 8082:8082 -v $(pwd)/model_store:/home/model-server/model-store/ sam-gpu:latest sh -c "cd /home/model-server && mkdir -p tmp/ && torchserve --foreground --ts-config ./config.properties"

--- a/start_serve_decode_cpu.sh
+++ b/start_serve_decode_cpu.sh
@@ -1,1 +1,1 @@
-docker run -it --rm -p 8080:8080 -p 8081:8081 -p 8082:8082 -v $(pwd)/model_store:/home/model-server/model-store/ sam-gpu:latest sh -c "cd /home/model-server && mkdir -p tmp/ && torchserve --foreground --ts-config ./config.properties"
+docker run -it --rm -p 8080:8080 -p 8081:8081 -p 8082:8082 -v $(pwd)/model-store:/home/model-server/model-store/ sam-gpu:latest sh -c "cd /home/model-server && mkdir -p tmp/ && torchserve --foreground --ts-config ./config.properties"

--- a/start_serve_encode_gpu.sh
+++ b/start_serve_encode_gpu.sh
@@ -1,1 +1,1 @@
-docker run -it -p 8080:8080 -p 8081:8081 -p 8082:8082 --gpus all torchserve-sam-gpu:latest serve
+docker run -it --rm -p 8080:8080 -p 8081:8081 -p 8082:8082 -v $(pwd)/model_store:/home/model-server/volume/model-store/ --gpus all sam-gpu:latest sh -c "cd /home/model-server && mkdir -p volume/tmp && torchserve --foreground --ts-config ./config.properties"

--- a/start_serve_encode_gpu.sh
+++ b/start_serve_encode_gpu.sh
@@ -1,1 +1,1 @@
-docker run -it --rm -p 8080:8080 -p 8081:8081 -p 8082:8082 -v $(pwd)/model_store:/home/model-server/volume/model-store/ --gpus all sam-gpu:latest sh -c "cd /home/model-server && mkdir -p volume/tmp && torchserve --foreground --ts-config ./config.properties"
+docker run -it --rm -p 8080:8080 -p 8081:8081 -p 8082:8082 -v $(pwd)/model-store:/home/model-server/volume/model-store/ --gpus all sam-gpu:latest sh -c "cd /home/model-server && mkdir -p volume/tmp && torchserve --foreground --ts-config ./config.properties"


### PR DESCRIPTION
## What I am changing
- I updated the readme to account for the separate build and serving containers. now you can test lcoally using the same build and serving containers use din the CloudFormation deployment
- added prediction exception in case the image is larger than 2048x2048.
- added higher caps for max request and response size to accept image sizes up to 2048x2048
- removed unneeded copy statement in serving containers

## How I did it

- edited handler for prediction exception
- edited readme to show docker commands for testing

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- see readme and use test_endpoint.ipynb

