### PR TITLE
Dashboards & Alerts

### DIFF
--- a/cloudformation/segment-anything-services.template.js
+++ b/cloudformation/segment-anything-services.template.js
@@ -40,13 +40,23 @@ export default cf.merge(
         }
     },
     ELBAlarms({
-        prefix: 'Batch',
+        prefix: 'CPU',
         email: cf.ref('AlarmEmail'),
         apache: cf.stackName,
         cluster: cf.ref('ECSCluster'),
         service: cf.getAtt('Service', 'Name'),
         loadbalancer: cf.getAtt('ELB', 'LoadBalancerFullName'),
         targetgroup: cf.getAtt('TargetGroup', 'TargetGroupFullName')
+
+    }),
+    ELBAlarms({
+        prefix: 'GPU',
+        email: cf.ref('AlarmEmail'),
+        apache: cf.stackName,
+        cluster: cf.ref('ECSCluster'),
+        service: cf.getAtt('GPUService', 'Name'),
+        loadbalancer: cf.getAtt('GPUELB', 'LoadBalancerFullName'),
+        targetgroup: cf.getAtt('GPUTargetGroup', 'TargetGroupFullName')
 
     })
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@openaddresses/cloudfriend": "^7.0.0"
             },
             "devDependencies": {
-                "@openaddresses/batch-alarms": "^3.2.0",
+                "@openaddresses/batch-alarms": "^4.0.0",
                 "eslint": "^8.38.0",
                 "eslint-plugin-node": "^11.1.0"
             }
@@ -600,9 +600,9 @@
             }
         },
         "node_modules/@openaddresses/batch-alarms": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/@openaddresses/batch-alarms/-/batch-alarms-3.2.0.tgz",
-            "integrity": "sha512-e7xZh7yPNrQWZbEb8E9IcMeI8rqkrf6hGYk3nGuhK13bs5ywYblLMjUDnTqsExnpC/nfw21kglxfpjD9v5ps6A==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@openaddresses/batch-alarms/-/batch-alarms-4.0.0.tgz",
+            "integrity": "sha512-i+JGMt8iwh8jJc+Tfu08cEqAsM3u79ZpfHsTLDGvQy9UfH9qK9K3wUKgKTAYPhorJ8zNueaAgnX6MIO2v1a36Q==",
             "dev": true,
             "dependencies": {
                 "@openaddresses/cloudfriend": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     },
     "homepage": "https://github.com/developmentseed/segment-anything-geo#readme",
     "devDependencies": {
-        "@openaddresses/batch-alarms": "^3.2.0",
+        "@openaddresses/batch-alarms": "^4.0.0",
         "eslint": "^8.38.0",
         "eslint-plugin-node": "^11.1.0"
     },


### PR DESCRIPTION
### Context

In order to scale down GPU ECS Tasks automatically we need to monitor HTTP requests and initiate a scaledown when requests are 0. This PR introduces an updated version of `batch-alarms` that supports multiple Dashboards in a single stack, allowing us to have alarms & metrics for both the CPU & GPU stacks simultaneously 
