### PR TITLE
Enable CORS requests from devseed.com

### DIFF
--- a/deployment/config_decode.properties
+++ b/deployment/config_decode.properties
@@ -7,3 +7,6 @@ job_queue_size=1000
 model_store=/home/model-server/volume/model-store
 load_models=all
 vmargs=-Xmx8g
+cors_allowed_origin=https://devseed.com
+cors_allowed_methods=GET, POST, PUT, OPTIONS
+cors_allowed_headers=X-Custom-Header

--- a/deployment/config_encode.properties
+++ b/deployment/config_encode.properties
@@ -8,3 +8,6 @@ load_models=all
 vmargs=-Xmx8g
 max_request_size=17797905
 max_response_size=17797905
+cors_allowed_origin=https://devseed.com
+cors_allowed_methods=GET, POST, PUT, OPTIONS
+cors_allowed_headers=X-Custom-Header


### PR DESCRIPTION
I didn't test it, but I think this is the solution. If you prefer to enable any domain, replace https://devseed.com by *