### PR TITLE
deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# Deprecation Notice
+This has been deprecated, check out the new open source backend for the geospatial imagery annotation tool [DS-Annotate](https://github.com/developmentseed/ds-annotate), https://github.com/GeoCompas/samgeo-service by [GeoCompas](https://geocompas.ai/)!
+
 # Segment Anything Encoder and Decoder as Services
 
 ![Oil slick captured by Sentinel-1 Segmented](slick_example.png)


### PR DESCRIPTION
Putting up a deprecation notice since GeoCompas is using and maintaining a new backend for DS-Annotate and this repo doesn't have an active maintainer or use. https://github.com/GeoCompas/samgeo-service

cc @Rub21 @batpad @geohacker 